### PR TITLE
fix: add key to ReactMarkdown

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -341,6 +341,7 @@ function Dashboard() {
 								{selectedPost.content ? (
 									<div className="prose prose-gray dark:prose-invert max-w-none prose-headings:text-foreground prose-p:text-foreground prose-a:text-primary prose-strong:text-foreground prose-code:text-foreground prose-pre:bg-muted prose-blockquote:text-muted-foreground prose-li:text-foreground space-y-4">
 										<ReactMarkdown
+											key={selectedPost.id}
 											remarkPlugins={[remarkGfm]}
 											rehypePlugins={[rehypeRaw, rehypeSanitize]}
 											components={markdownComponents}


### PR DESCRIPTION
- Adds `id` field to `ReactMarkdown` to prevent rendering issues while using features that manipulate the DOM, such as Google Translate 